### PR TITLE
Rename remote_tag() to remove_tag()

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -216,7 +216,7 @@ def add_tag_to_question(request):
     DAL.tags.add_to_question(tag)
 
 
-def remote_tag_from_question(question_id, tag_id):
+def remove_tag_from_question(question_id, tag_id):
     DAL.tags.remove_from_question(question_id, tag_id)
 
 

--- a/server.py
+++ b/server.py
@@ -210,9 +210,9 @@ def add_tag(question_id):
 
 
 @app.route('/question/<int:question_id>/tag/<int:tag_id>/delete')
-def remote_tag_from_question(question_id, tag_id):
+def remove_tag_from_question(question_id, tag_id):
     if data_handler.is_logged_in(session):
-        data_handler.remote_tag_from_question(question_id, tag_id)
+        data_handler.remove_tag_from_question(question_id, tag_id)
     else:
         return redirect('/login')
     return redirect(request.referrer)


### PR DESCRIPTION
Rewrites "remote_tag" to "remove_tag" in function name